### PR TITLE
Rewrite AGENTS guidelines in English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# Guidelines for AI developers
+
+This document defines the main guidelines for contributing to this repository.
+
+## Repository structure
+- Analyze the project structure before modifying files.
+- Check the README and any other documentation for specific instructions.
+
+## Contributions
+- Write commit messages in English, clearly and concisely.
+- Briefly describe the changes in the commit body.
+- Summarize the tests performed and results in the pull request message, if possible.
+
+## Code
+- Follow the best practices of the programming language used.
+- Avoid unnecessary dependencies.
+- Document any added or modified code.
+- All code comments and project documentation must be in English.
+
+## Testing
+- Run automatic tests, if present, before submitting the pull request.
+- Report any errors or issues encountered during execution.
+
+## Pull Request
+- Provide a summary of the changes made and the test results.
+- Ensure the pull request complies with these guidelines.


### PR DESCRIPTION
## Summary
- rewrite AGENTS guidelines completely in English
- clarify that code comments and documentation must be in English

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_6884e806b4b483328c70dd52c22562a9