### PR TITLE
Add docs directory requirement to guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@ This document defines the main guidelines for contributing to this repository.
 ## Repository structure
 - Analyze the project structure before modifying files.
 - Check the README and any other documentation for specific instructions.
+- Store all project documentation inside the `docs` directory.
 
 ## Contributions
 - Write commit messages in English, clearly and concisely.


### PR DESCRIPTION
## Summary
- clarify that all documentation must be stored in the `docs` directory

## Testing
- `find . -name AGENTS.md -print`

------
https://chatgpt.com/codex/tasks/task_b_6884f21d811c833284843d27a53f4892