### PR TITLE
Update diagrams with Dapr pub/sub events

### DIFF
--- a/docs/commander_create_sequence.mmd
+++ b/docs/commander_create_sequence.mmd
@@ -11,6 +11,7 @@ sequenceDiagram
         participant ResourceActor as Resource Actor
         participant Cerbos as Cerbos PDP
     end
+    participant EventBroker as Event Broker
 
     Client->>+EnvoyProxy: POST /resources + JWT
     note over Client,EnvoyProxy: 1. Client request authenticated by Envoy
@@ -37,6 +38,9 @@ sequenceDiagram
             else
                 Cerbos-->>ResourceActor: Allowed
                 ResourceActor->>ResourceActor: Save state
+                ResourceActor->>+ActorDaprd: Publish created event via pub/sub
+                ActorDaprd->>EventBroker: CloudEvent
+                ActorDaprd-->>ResourceActor: Event published
                 ResourceActor-->>ActorDaprd: 201 Created
             end
             deactivate Cerbos

--- a/docs/commander_delete_sequence.mmd
+++ b/docs/commander_delete_sequence.mmd
@@ -11,6 +11,7 @@ sequenceDiagram
         participant ResourceActor as Resource Actor
         participant Cerbos as Cerbos PDP
     end
+    participant EventBroker as Event Broker
 
     Client->>+EnvoyProxy: DELETE /resources/{id} + JWT
     note over Client,EnvoyProxy: 1. Client request authenticated by Envoy
@@ -36,6 +37,9 @@ sequenceDiagram
             ActorDaprd-->>ResourceActor: State saved
             ResourceActor->>+ActorDaprd: Register cleanup reminder
             ActorDaprd-->>ResourceActor: Reminder scheduled
+            ResourceActor->>+ActorDaprd: Publish deleted event via pub/sub
+            ActorDaprd->>EventBroker: CloudEvent
+            ActorDaprd-->>ResourceActor: Event published
             ResourceActor-->>ActorDaprd: 204 No Content
         end
         deactivate Cerbos

--- a/docs/commander_update_sequence.mmd
+++ b/docs/commander_update_sequence.mmd
@@ -11,6 +11,7 @@ sequenceDiagram
         participant ResourceActor as Resource Actor
         participant Cerbos as Cerbos PDP
     end
+    participant EventBroker as Event Broker
 
     Client->>+EnvoyProxy: PUT /resources/:id + JWT
     note over Client,EnvoyProxy: 1. Client request authenticated by Envoy
@@ -37,6 +38,9 @@ sequenceDiagram
             else
                 Cerbos-->>ResourceActor: Allowed
                 ResourceActor->>ResourceActor: Save state
+                ResourceActor->>+ActorDaprd: Publish updated event via pub/sub
+                ActorDaprd->>EventBroker: CloudEvent
+                ActorDaprd-->>ResourceActor: Event published
                 ResourceActor-->>ActorDaprd: 200 OK
             end
             deactivate Cerbos

--- a/docs/resource_creation.md
+++ b/docs/resource_creation.md
@@ -17,7 +17,7 @@ A graphical representation of the sequence is available in [commander_create_seq
 7. **Schema validation** – The temporary resource is validated against the configured schema. If validation fails the actor returns `422 Unprocessable Entity`.
 8. **Authorization** – The actor queries the Cerbos PDP sidecar, passing the temporary resource and the user's JWT. A `403 Forbidden` response is returned if the action is denied.
 9. **State persistence** – When authorization succeeds the actor stores the resource in its state, updates the `metadata` fields (including the ETag and creation timestamp) and persists the state.
-10. **Domain event** – After saving the state the actor emits a domain event notifying other services of the new resource creation.
+10. **Domain event** – After saving the state the actor emits a domain event via Dapr's pub/sub API to notify other services of the new resource creation.
 11. **Response** – The actor responds with `201 Created` and the generated resource ID. Commander relays this response back to the client.
 
 For the deletion process see [resource_deletion.md](resource_deletion.md).

--- a/docs/resource_deletion.md
+++ b/docs/resource_deletion.md
@@ -15,6 +15,6 @@ A graphical representation of the sequence is available in [commander_delete_seq
 5. **State check** – The actor loads the current state. If no state exists the actor returns `404 Not Found`.
 6. **Authorization** – When the resource exists the actor queries Cerbos with the state and the user's JWT. A `403 Forbidden` response is returned if the deletion is denied.
 7. **Soft delete** – If allowed the actor sets `.metadata.deleted` to the current timestamp, persists the new state through Dapr and registers a reminder for physical deletion.
-8. **Domain event** – The actor emits a domain event notifying other services about the deletion.
+8. **Domain event** – The actor emits a domain event via Dapr's pub/sub API notifying other services about the deletion.
 9. **Response** – The actor responds with `204 No Content`. Commander relays this status to the client.
 10. **Cleanup reminder** – When the reminder fires Dapr calls the actor again. If the deletion timestamp is older than the configured threshold the actor permanently removes the state.

--- a/docs/resource_update.md
+++ b/docs/resource_update.md
@@ -17,5 +17,5 @@ A graphical representation of the sequence is available in [commander_update_seq
 7. **Schema validation** – The updated resource is validated against the configured schema. If validation fails the actor returns `422 Unprocessable Entity`.
 8. **Authorization** – The actor queries the Cerbos PDP sidecar to check whether the user is allowed to perform the update. A `403 Forbidden` response is returned when the action is denied.
 9. **State persistence** – When authorization succeeds the actor stores the updated resource, updates the `metadata` fields (including the ETag) and persists the state.
-10. **Domain event** – After saving the state the actor emits an event describing the modification.
+10. **Domain event** – After saving the state the actor emits an event describing the modification using Dapr's pub/sub API.
 11. **Response** – The actor responds with `200 OK` and the updated resource data. Commander relays this response back to the client.


### PR DESCRIPTION
## Summary
- clarify that domain events are published through Dapr pub/sub
- update docs about create, update and delete workflows accordingly

## Testing
- `docker run --rm -v $(pwd)/docs:/docs plantuml/plantuml -check docs/puml/*.puml` *(fails: `docker` not found)*
- `docker run --rm -v $(pwd)/docs:/docs ghcr.io/mermaid-js/mermaid-cli mmdc -i docs/commander_create_sequence.mmd -o /tmp/create.svg` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6889c7009c54833298f7eb50750b2f1d